### PR TITLE
Python 3.2 Compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Due to Facebook's policies, I cannot download your friend's email addresses, ins
 
 ### Requirements
 
-Python 2.6, which can be found here: <http://www.python.org/download/>
+Python 2.6, 2.7, or 3.2, which can be found here: <http://www.python.org/download/>
 
 ### Usage
 


### PR DESCRIPTION
Python 3.x compatibility fixes (without breaking 2.x compatibility). scrapebook.py now works in Python 3.2.
